### PR TITLE
Resolves the incorrect time sequence of the WFH curve when height at …

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -25,17 +25,11 @@ set_xout <- function(chartcode, yname) {
   if (design == "A") {
     return(round(seq(0.5, 15, 0.5) / 12, 4L))
   }
-  if (design == "B" & yname == "wfh") {
-    return(round(seq(50, 120, by = 2), 4L))
-  }
   if (design == "B" & yname %in% c("hgt", "dsc")) {
     return(round(c(0.5, 0.75, 1:48) / 12, 4L))
   }
-  if (design == "B" & yname == "hdc") {
+  if (design == "B" & yname %in% c("hdc", "wfh")) {
     return(round(seq(0.1, 4, by = 0.1), 4L))
-  }
-  if (design == "C" & yname == "wfh") {
-    return(round(seq(60, 184, by = 4), 4L))
   }
   if (design == "C") {
     return(round(seq(1, 21, by = 0.5), 4L))

--- a/R/set_curves.R
+++ b/R/set_curves.R
@@ -37,9 +37,13 @@ set_curves <- function(g,
     mutate(
       id = -1,
       sex = child$sex,
-      ga = child$ga
+      ga = child$ga,
+      x2 = .data$x
     ) %>%
-    select(all_of(c("id", "age", "xname", "yname", "x", "y", "sex", "ga")))
+    select(all_of(c("id", "age", "xname", "yname", "x", "y", "sex", "ga", "x2")))
+  # For WFH, temporary sort on age to get correct time sequence, use x2 to store x
+  idx <- data$yname == "wfh"
+  data$x[idx] <- data$age[idx]
 
   # get data of matches
   time <- vector("list", length(ynames))
@@ -107,7 +111,17 @@ set_curves <- function(g,
   # append synthetic data
   data <- data %>%
     bind_rows(synt) %>%
-    arrange(.data$id, .data$yname, .data$x, .data$age) %>%
+    arrange(.data$id, .data$yname, .data$x)
+
+  # For wfh, interpolate hgt from age, and overwrite data$x with hgt
+  idx <- data$yname == "wfh"
+  if (any(idx)) {
+    data$x[idx] <- safe_approx(x = data$x[idx], y = data$x2[idx],
+                               xout = data$x[idx], ties = list("ordered", mean))$y
+  }
+
+  # add Z-scores
+  data <- data %>%
     select(-"age") %>%  # fool set_refcodes()
     mutate(refcode_z = nlreferences::set_refcodes(.)) %>%
     mutate(
@@ -133,8 +147,7 @@ set_curves <- function(g,
     group_by(.data$id, .data$yname, .data$pred) %>%
     mutate(z = safe_approx(
       x = .data$x, y = .data$z, xout = .data$x,
-      ties = list("ordered", mean)
-    )$y) %>%
+      ties = mean)$y) %>%
     ungroup()
 
   # set refcode as target's sex and ga


### PR DESCRIPTION
Resolves the incorrect time sequence of the WFH curve when height at a later age is lower. See <https://github.com/growthcharts/james/issues/24>

It works for `curve_interpolation` is `FALSE`. Some approximation error remain for `curve_interpolation` is `TRUE`.